### PR TITLE
label sizing fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,12 @@ jobs:
           name: ipyelk dist ${{ github.run_number }}
           path: ./dist
 
-      - name: report (robot)
+      - name: reports
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ job.status }} Robot ${{ matrix.os }} ${{ github.run_number }}
-          path: ./atest/output
+          name: ${{ job.status }} reports ${{ matrix.os }} ${{ github.run_number }}
+          path: |
+            ./atest/output
+            ./build/htmcov
+            ./build/pytest.html
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo
@@ -67,8 +68,10 @@ docs/source/_static/embed-bundle.js.map
 # PyBuilder
 target/
 
-# IPython Notebook
+# Jupyter
 .ipynb_checkpoints
+untitled*
+Untitled*
 
 # pyenv
 .python-version
@@ -165,5 +168,3 @@ py_src/ipyelk/schema/*.json
 .doit*
 .pabotsuitenames
 atest/output
-untitled*
-Untitled*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@
 
 ## ipyelk 0.2.1
 
-- update Elk schema to allow for properties on edge labels and port labels ([#48][])
+- update Elk schema to allow for properties (and c) on edge labels and port labels
+  ([#48][])
+- Merge layout options if specified in a given node's data with default layout options
+  ([#48][])
 
 [#46]: https://github.com/jupyrdf/ipyelk/pull/46
 [#48]: https://github.com/jupyrdf/ipyelk/pull/48

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## @jupyrdf/jupyter-elk 0.2.1
 
 - fix `ElkTransformer` handling of custom properties ([#46][])
+- add `ElkTextSizer` passing through of custom css style when sizing labels ([#48][])
 
 ## ipyelk 0.2.1
 
-> TBD
+- update Elk schema to allow for properties on edge labels and port labels ([#48][])
 
 [#46]: https://github.com/jupyrdf/ipyelk/pull/46
+[#48]: https://github.com/jupyrdf/ipyelk/pull/48
 
 ---
 

--- a/anaconda-project-lock.yml
+++ b/anaconda-project-lock.yml
@@ -17,15 +17,20 @@ locking_enabled: true
 env_specs:
   ipyelk:
     locked: false
+  _lint:
+    locked: false
+  _utest:
+    locked: false
   default:
     locked: true
-    env_spec_hash: 9cb03abb34e23307dfc39011e13ac5934092547b
+    env_spec_hash: b00fef94d2a2f103b777c177b56f90dfcf7fdc44
     platforms:
       - linux-64
       - osx-64
       - win-64
     packages:
       all:
+        - apipkg=1.5=py_0
         - appdirs=1.4.4=pyh9f0ad1d_0
         - async-lru=1.0.2=py_0
         - async_generator=1.10=py_0
@@ -41,11 +46,15 @@ env_specs:
         - decorator=4.4.2=py_0
         - defusedxml=0.6.0=py_0
         - entrypoints=0.3=pyhd8ed1ab_1003
+        - execnet=1.7.1=py_0
         - flake8=3.8.4=py_0
+        - hypothesis-jsonschema=0.18.2=pyhd8ed1ab_0
+        - hypothesis=5.41.4=pyhd8ed1ab_0
         - idna=2.10=pyh9f0ad1d_0
-        - importlib-metadata=2.0.0=py_1
-        - importlib_metadata=2.0.0=1
+        - importlib-metadata=3.1.1=pyhd8ed1ab_0
+        - importlib_metadata=3.1.1=hd8ed1ab_0
         - importnb=0.7.0=pyhd8ed1ab_0
+        - iniconfig=1.1.1=pyh9f0ad1d_0
         - ipython_genutils=0.2.0=py_1
         - ipywidgets=7.5.1=pyh9f0ad1d_1
         - isort=4.3.21=py37hc8dfbb8_1
@@ -56,11 +65,10 @@ env_specs:
         - jupyterlab=1.2.16=py_0
         - jupyterlab_pygments=0.1.2=pyh9f0ad1d_0
         - jupyterlab_server=1.2.0=py_0
-        - keyring=21.4.0=py37hc8dfbb8_2
         - mccabe=0.6.1=py_1
+        - more-itertools=8.6.0=pyhd8ed1ab_0
         - mypy_extensions=0.4.3=py37hc8dfbb8_2
         - nbclient=0.5.1=py_0
-        - nbconvert=6.0.7=py37hc8dfbb8_2
         - nbformat=5.0.8=py_0
         - nest-asyncio=1.4.3=pyhd8ed1ab_0
         - networkx=2.5=py_0
@@ -69,16 +77,22 @@ env_specs:
         - parso=0.7.1=pyh9f0ad1d_0
         - pathspec=0.8.1=pyhd3deb0d_0
         - pickleshare=0.7.5=py_1003
-        - pip=20.2.4=py_0
+        - pip=20.3=pyhd8ed1ab_0
         - pkginfo=1.6.1=pyh9f0ad1d_0
-        - prometheus_client=0.8.0=pyh9f0ad1d_0
+        - prometheus_client=0.9.0=pyhd3deb0d_0
         - prompt-toolkit=3.0.8=pyha770c72_0
+        - py=1.9.0=pyh9f0ad1d_0
         - pycodestyle=2.6.0=pyh9f0ad1d_0
         - pycparser=2.20=pyh9f0ad1d_2
         - pyflakes=2.2.0=pyh9f0ad1d_0
         - pygments=2.7.2=py_0
-        - pyopenssl=19.1.0=py_1
+        - pyopenssl=20.0.0=pyhd8ed1ab_0
         - pyparsing=2.4.7=pyh9f0ad1d_0
+        - pytest-cov=2.10.1=pyh9f0ad1d_0
+        - pytest-forked=1.2.0=pyh9f0ad1d_0
+        - pytest-html=3.0.0=pyhd8ed1ab_0
+        - pytest-metadata=1.11.0=pyhd3deb0d_0
+        - pytest-xdist=2.1.0=py_0
         - python-dateutil=2.8.1=py_0
         - python_abi=3.7=1_cp37m
         - pytz=2020.4=pyhd8ed1ab_0
@@ -88,53 +102,56 @@ env_specs:
         - rfc3986=1.4.0=pyh9f0ad1d_0
         - send2trash=1.5.0=py_0
         - six=1.15.0=pyh9f0ad1d_0
+        - sortedcontainers=2.3.0=pyhd8ed1ab_0
         - testpath=0.4.4=py_0
         - toml=0.10.2=pyhd8ed1ab_0
-        - tqdm=4.51.0=pyh9f0ad1d_0
+        - tqdm=4.54.0=pyhd8ed1ab_0
         - traitlets=5.0.5=py_0
         - twine=3.2.0=py37hc8dfbb8_1
         - typing_extensions=3.7.4.3=py_0
         - urllib3=1.25.11=py_0
         - wcwidth=0.2.5=pyh9f0ad1d_2
         - webencodings=0.5.1=py_1
-        - wheel=0.35.1=pyh9f0ad1d_0
-        - widgetsnbextension=3.5.1=py37hc8dfbb8_4
+        - wheel=0.36.0=pyhd3deb0d_0
         - zipp=3.4.0=py_0
       unix:
-        - ipykernel=5.3.4=py37hc6149b9_1
-        - libblas=3.9.0=2_openblas
-        - libcblas=3.9.0=2_openblas
-        - liblapack=3.9.0=2_openblas
+        - libblas=3.9.0=3_openblas
+        - libcblas=3.9.0=3_openblas
+        - liblapack=3.9.0=3_openblas
         - pexpect=4.8.0=pyh9f0ad1d_2
         - ptyprocess=0.6.0=py_1001
       linux-64:
         - _libgcc_mutex=0.1=conda_forge
         - _openmp_mutex=4.5=1_gnu
-        - argon2-cffi=20.1.0=py37h8f50634_2
+        - ansi2html=1.6.0=py37h89c1867_0
+        - argon2-cffi=20.1.0=py37h4abf009_2
         - brotlipy=0.7.0=py37hb5d75c8_1001
         - ca-certificates=2020.11.8=ha878542_0
         - certifi=2020.11.8=py37h89c1867_0
-        - cffi=1.14.3=py37h00ebd2e_1
+        - cffi=1.14.4=py37hc58025e_1
         - chardet=3.0.4=py37he5f6b98_1008
         - cmarkgfm=0.4.2=py37h8f50634_3
+        - coverage=5.3=py37h8f50634_1
         - cryptography=3.2.1=py37hc72a4ac_0
         - dbus=1.13.6=hfdff14a_1
         - docutils=0.16=py37he5f6b98_2
         - expat=2.2.9=he1b5a44_2
-        - gettext=0.19.8.1=hf34092f_1004
-        - glib=2.66.2=h58526e2_0
-        - icu=67.1=he1b5a44_0
+        - gettext=0.19.8.1=h0b5b191_1005
+        - glib=2.66.3=h9c3ff4c_1
+        - icu=68.1=h58526e2_0
         - importlib_resources=3.3.0=py37h89c1867_0
+        - ipykernel=5.3.4=py37h888b3d9_1
         - ipython=7.19.0=py37h888b3d9_0
         - jedi=0.17.2=py37h89c1867_1
-        - jeepney=0.4.3=py_0
-        - jupyter_core=4.6.3=py37h89c1867_2
-        - ld_impl_linux-64=2.35=h769bd43_9
-        - libffi=3.2.1=he1b5a44_1007
+        - jeepney=0.6.0=pyhd8ed1ab_0
+        - jupyter_core=4.7.0=py37h89c1867_0
+        - keyring=21.5.0=py37h89c1867_0
+        - ld_impl_linux-64=2.35.1=hed1e6ac_0
+        - libffi=3.3=h58526e2_1
         - libgcc-ng=9.3.0=h5dbcf3e_17
         - libgfortran-ng=9.3.0=he4bcb1c_17
         - libgfortran5=9.3.0=he4bcb1c_17
-        - libglib=2.66.2=hbe7bbb4_0
+        - libglib=2.66.3=h1f3bc88_1
         - libgomp=9.3.0=h5dbcf3e_17
         - libiconv=1.16=h516909a_0
         - libopenblas=0.3.12=pthreads_h4812303_1
@@ -143,48 +160,57 @@ env_specs:
         - libuv=1.40.0=hd18ef5c_0
         - markupsafe=1.1.1=py37hb5d75c8_2
         - mistune=0.8.4=py37h4abf009_1002
-        - ncurses=6.2=h58526e2_3
-        - nodejs=14.14.0=h914e61d_0
+        - nbconvert=6.0.7=py37h89c1867_3
+        - ncurses=6.2=h58526e2_4
+        - nodejs=14.15.1=h25f6087_0
         - notebook=6.1.5=py37h89c1867_0
         - numpy=1.19.4=py37h7e9df27_1
         - openssl=1.1.1h=h516909a_0
         - pandas=1.1.4=py37h10a2094_0
-        - pandoc=2.11.1.1=h36c2ea0_0
+        - pandoc=2.11.2=h36c2ea0_0
         - pcre=8.44=he1b5a44_0
+        - pluggy=0.13.1=py37he5f6b98_3
         - pyrsistent=0.17.3=py37h4abf009_1
         - pysocks=1.7.1=py37he5f6b98_2
-        - python=3.7.8=h6f2ec95_1_cpython
-        - pyzmq=19.0.2=py37hac76be4_2
+        - pytest-asyncio=0.14.0=py37h89c1867_0
+        - pytest=6.1.2=py37h89c1867_0
+        - python=3.7.8=hffdb5ce_3_cpython
+        - pyzmq=20.0.0=py37h5a562af_1
         - readline=8.0=he28a2e2_2
-        - regex=2020.11.11=py37h4abf009_0
-        - secretstorage=3.2.0=py37h89c1867_0
+        - regex=2020.11.13=py37h4abf009_0
+        - secretstorage=3.3.0=py37h89c1867_0
         - setuptools=49.6.0=py37he5f6b98_2
-        - sqlite=3.33.0=h4cf870e_1
+        - sqlite=3.34.0=h74cdb3f_0
         - terminado=0.9.1=py37h89c1867_1
         - tk=8.6.10=hed695b0_1
         - tornado=6.1=py37h4abf009_0
         - typed-ast=1.4.1=py37h4abf009_1
+        - widgetsnbextension=3.5.1=py37h89c1867_4
         - xz=5.2.5=h516909a_1
-        - zeromq=4.3.3=h58526e2_2
+        - zeromq=4.3.3=h58526e2_3
         - zlib=1.2.11=h516909a_1010
       osx-64:
-        - appnope=0.1.0=py37hf985489_1002
-        - argon2-cffi=20.1.0=py37h60d8a13_2
+        - ansi2html=1.6.0=py37hf985489_0
+        - appnope=0.1.2=py37hf985489_0
+        - argon2-cffi=20.1.0=py37h4b544eb_2
         - brotlipy=0.7.0=py37h395d20d_1001
         - ca-certificates=2020.11.8=h033912b_0
         - certifi=2020.11.8=py37hf985489_0
-        - cffi=1.14.3=py37h446cb54_1
+        - cffi=1.14.4=py37hc5b2277_1
         - chardet=3.0.4=py37h2987424_1008
         - cmarkgfm=0.4.2=py37h60d8a13_3
+        - coverage=5.3=py37h60d8a13_1
         - cryptography=3.2.1=py37h3b7a55b_0
         - docutils=0.16=py37h2987424_2
-        - icu=67.1=hb1e8313_0
+        - icu=68.1=h74dc148_0
         - importlib_resources=3.3.0=py37hf985489_0
+        - ipykernel=5.3.4=py37he01cfaa_1
         - ipython=7.19.0=py37he01cfaa_0
         - jedi=0.17.2=py37hf985489_1
-        - jupyter_core=4.6.3=py37hf985489_2
-        - libcxx=11.0.0=h439d374_0
-        - libffi=3.2.1=hb1e8313_1007
+        - jupyter_core=4.7.0=py37hf985489_0
+        - keyring=21.5.0=py37hf985489_0
+        - libcxx=11.0.0=h4c3b8ed_1
+        - libffi=3.3=h74dc148_1
         - libgfortran5=9.3.0=h7cc5361_13
         - libgfortran=5.0.0=h7cc5361_13
         - libopenblas=0.3.12=openmp_h54245bb_1
@@ -193,36 +219,44 @@ env_specs:
         - llvm-openmp=11.0.0=h73239a0_1
         - markupsafe=1.1.1=py37h395d20d_2
         - mistune=0.8.4=py37h4b544eb_1002
-        - ncurses=6.2=h2e338ed_3
-        - nodejs=14.14.0=h29ef208_0
+        - nbconvert=6.0.7=py37hf985489_3
+        - ncurses=6.2=h2e338ed_4
+        - nodejs=14.15.1=heaeed3d_0
         - notebook=6.1.5=py37hf985489_0
         - numpy=1.19.4=py37h9ebeaaa_1
         - openssl=1.1.1h=haf1e3a3_0
         - pandas=1.1.4=py37h9b0e0a3_0
-        - pandoc=2.11.1.1=hbcb3906_0
+        - pandoc=2.11.2=hc929b4f_0
+        - pluggy=0.13.1=py37h2987424_3
         - pyrsistent=0.17.3=py37h4b544eb_1
         - pysocks=1.7.1=py37h2987424_2
-        - python=3.7.8=hc9dea61_1_cpython
-        - pyzmq=19.0.2=py37hf1e22d8_2
+        - pytest-asyncio=0.14.0=py37hf985489_0
+        - pytest=6.1.2=py37hf985489_0
+        - python=3.7.8=h4f09611_3_cpython
+        - pyzmq=20.0.0=py37h47fd9b3_1
         - readline=8.0=h0678c8f_2
-        - regex=2020.11.11=py37h4b544eb_0
+        - regex=2020.11.13=py37h4b544eb_0
         - setuptools=49.6.0=py37h2987424_2
-        - sqlite=3.33.0=h960bd1c_1
+        - sqlite=3.34.0=h17101e1_0
         - terminado=0.9.1=py37hf985489_1
         - tk=8.6.10=hb0a8c7a_1
         - tornado=6.1=py37h4b544eb_0
         - typed-ast=1.4.1=py37h4b544eb_1
+        - widgetsnbextension=3.5.1=py37hf985489_4
         - xz=5.2.5=haf1e3a3_1
-        - zeromq=4.3.3=h2e338ed_2
+        - zeromq=4.3.3=h74dc148_3
         - zlib=1.2.11=h7795811_1010
       win-64:
-        - argon2-cffi=20.1.0=py37h4ab8f01_2
+        - ansi2html=1.6.0=py37h03978a9_0
+        - argon2-cffi=20.1.0=py37hcc03f2d_2
+        - atomicwrites=1.4.0=pyh9f0ad1d_0
         - brotlipy=0.7.0=py37h0013d47_1001
         - ca-certificates=2020.11.8=h5b45459_0
         - certifi=2020.11.8=py37h03978a9_0
-        - cffi=1.14.3=py37hd6b71e5_1
+        - cffi=1.14.4=py37hd8e9650_1
         - chardet=3.0.4=py37hf50a25e_1008
         - cmarkgfm=0.4.2=py37h4ab8f01_3
+        - coverage=5.3=py37h4ab8f01_1
         - cryptography=3.2.1=py37hd8e9650_0
         - docutils=0.16=py37hf50a25e_2
         - importlib_resources=3.3.0=py37h03978a9_0
@@ -230,10 +264,11 @@ env_specs:
         - ipykernel=5.3.4=py37h7b7c402_1
         - ipython=7.19.0=py37heaed05f_0
         - jedi=0.17.2=py37h03978a9_1
-        - jupyter_core=4.6.3=py37h03978a9_2
-        - libblas=3.8.0=20_mkl
-        - libcblas=3.8.0=20_mkl
-        - liblapack=3.8.0=20_mkl
+        - jupyter_core=4.7.0=py37h03978a9_0
+        - keyring=21.5.0=py37h03978a9_0
+        - libblas=3.8.0=21_mkl
+        - libcblas=3.8.0=21_mkl
+        - liblapack=3.8.0=21_mkl
         - libsodium=1.0.18=h8d14728_1
         - m2w64-gcc-libgfortran=5.3.0=6
         - m2w64-gcc-libs-core=5.3.0=7
@@ -242,33 +277,38 @@ env_specs:
         - m2w64-libwinpthread-git=5.0.0.4634.697f757=2
         - markupsafe=1.1.1=py37h0013d47_2
         - mistune=0.8.4=py37hcc03f2d_1002
-        - mkl=2020.2=256
+        - mkl=2020.4=hb70f87d_311
         - msys2-conda-epoch=20160418=1
-        - nodejs=14.14.0=h57928b3_0
+        - nbconvert=6.0.7=py37h03978a9_3
+        - nodejs=14.15.1=h57928b3_0
         - notebook=6.1.5=py37h03978a9_0
         - numpy=1.19.4=py37hd20adf4_1
         - openssl=1.1.1h=he774522_0
         - pandas=1.1.4=py37h08fd248_0
-        - pandoc=2.11.1.1=h8ffe710_0
+        - pandoc=2.11.2=h8ffe710_0
+        - pluggy=0.13.1=py37hf50a25e_3
         - pyrsistent=0.17.3=py37hcc03f2d_1
         - pysocks=1.7.1=py37hf50a25e_2
-        - python=3.7.8=h60c2a47_1_cpython
+        - pytest-asyncio=0.14.0=py37h03978a9_0
+        - pytest=6.1.2=py37h03978a9_0
+        - python=3.7.8=h7840368_3_cpython
         - pywin32-ctypes=0.2.0=py37hc8dfbb8_1002
         - pywin32=228=py37h4ab8f01_0
         - pywinpty=0.5.7=py37hc8dfbb8_1
-        - pyzmq=19.0.2=py37h453f00a_2
-        - regex=2020.11.11=py37hcc03f2d_0
+        - pyzmq=20.0.0=py37h0d95fc2_1
+        - regex=2020.11.13=py37hcc03f2d_0
         - setuptools=49.6.0=py37hf50a25e_2
-        - sqlite=3.33.0=he774522_1
+        - sqlite=3.34.0=h8ffe710_0
         - terminado=0.9.1=py37h03978a9_1
         - tornado=6.1=py37hcc03f2d_0
         - typed-ast=1.4.1=py37hcc03f2d_1
         - vc=14.1=h869be7e_1
         - vs2015_runtime=14.16.27012=h30e32a0_2
+        - widgetsnbextension=3.5.1=py37h03978a9_4
         - win_inet_pton=1.1.0=py37hc8dfbb8_1
         - wincertstore=0.2=py37hc8dfbb8_1005
         - winpty=0.4.3=4
-        - zeromq=4.3.2=ha925a31_4
+        - zeromq=4.3.3=h0e60522_3
   atest:
     locked: true
     env_spec_hash: a3cbc653618884c4eb2c0cda4abc326eac9894ad
@@ -279,41 +319,41 @@ env_specs:
     packages:
       all:
         - idna=2.10=pyh9f0ad1d_0
-        - pip=20.2.4=py_0
+        - pip=20.3=pyhd8ed1ab_0
         - pycparser=2.20=pyh9f0ad1d_2
-        - pyopenssl=19.1.0=py_1
+        - pyopenssl=20.0.0=pyhd8ed1ab_0
         - python_abi=3.7=1_cp37m
         - robotframework-lint=1.1=pyh9f0ad1d_0
         - robotframework-pabot=1.10.0=py_0
-        - robotframework-pythonlibcore=2.1.0=py_0
+        - robotframework-pythonlibcore=2.1.0=pyhd8ed1ab_1
         - robotframework-seleniumlibrary=4.5.0=pyh9f0ad1d_0
         - robotframework=3.2.2=pyh9f0ad1d_0
         - six=1.15.0=pyh9f0ad1d_0
-        - urllib3=1.26.1=pyhd8ed1ab_0
-        - wheel=0.35.1=pyh9f0ad1d_0
+        - urllib3=1.26.2=pyhd8ed1ab_0
+        - wheel=0.36.0=pyhd3deb0d_0
       linux-64:
         - _libgcc_mutex=0.1=conda_forge
         - _openmp_mutex=4.5=1_gnu
         - brotlipy=0.7.0=py37hb5d75c8_1001
         - ca-certificates=2020.11.8=ha878542_0
         - certifi=2020.11.8=py37h89c1867_0
-        - cffi=1.14.3=py37h00ebd2e_1
+        - cffi=1.14.4=py37hc58025e_1
         - cryptography=3.2.1=py37hc72a4ac_0
-        - firefox=82.0=he1b5a44_0
+        - firefox=83.0=h58526e2_0
         - geckodriver=0.28.0=h58526e2_0
-        - ld_impl_linux-64=2.35=h769bd43_9
-        - libffi=3.2.1=he1b5a44_1007
+        - ld_impl_linux-64=2.35.1=hed1e6ac_0
+        - libffi=3.3=h58526e2_1
         - libgcc-ng=9.3.0=h5dbcf3e_17
         - libgomp=9.3.0=h5dbcf3e_17
         - libstdcxx-ng=9.3.0=h2ae2ef3_17
-        - ncurses=6.2=h58526e2_3
+        - ncurses=6.2=h58526e2_4
         - openssl=1.1.1h=h516909a_0
         - pysocks=1.7.1=py37he5f6b98_2
-        - python=3.7.8=h6f2ec95_1_cpython
+        - python=3.7.8=hffdb5ce_3_cpython
         - readline=8.0=he28a2e2_2
         - selenium=3.141.0=py37h8f50634_1002
         - setuptools=49.6.0=py37he5f6b98_2
-        - sqlite=3.33.0=h4cf870e_1
+        - sqlite=3.34.0=h74cdb3f_0
         - tk=8.6.10=hed695b0_1
         - xz=5.2.5=h516909a_1
         - zlib=1.2.11=h516909a_1010
@@ -321,20 +361,20 @@ env_specs:
         - brotlipy=0.7.0=py37h395d20d_1001
         - ca-certificates=2020.11.8=h033912b_0
         - certifi=2020.11.8=py37hf985489_0
-        - cffi=1.14.3=py37h446cb54_1
+        - cffi=1.14.4=py37hc5b2277_1
         - cryptography=3.2.1=py37h3b7a55b_0
-        - firefox=82.0=hb1e8313_0
+        - firefox=83.0=h74dc148_0
         - geckodriver=0.28.0=h2e338ed_0
-        - libcxx=11.0.0=h439d374_0
-        - libffi=3.2.1=hb1e8313_1007
-        - ncurses=6.2=h2e338ed_3
+        - libcxx=11.0.0=h4c3b8ed_1
+        - libffi=3.3=h74dc148_1
+        - ncurses=6.2=h2e338ed_4
         - openssl=1.1.1h=haf1e3a3_0
         - pysocks=1.7.1=py37h2987424_2
-        - python=3.7.8=hc9dea61_1_cpython
+        - python=3.7.8=h4f09611_3_cpython
         - readline=8.0=h0678c8f_2
         - selenium=3.141.0=py37h60d8a13_1002
         - setuptools=49.6.0=py37h2987424_2
-        - sqlite=3.33.0=h960bd1c_1
+        - sqlite=3.34.0=h17101e1_0
         - tk=8.6.10=hb0a8c7a_1
         - xz=5.2.5=haf1e3a3_1
         - zlib=1.2.11=h7795811_1010
@@ -342,16 +382,16 @@ env_specs:
         - brotlipy=0.7.0=py37h0013d47_1001
         - ca-certificates=2020.11.8=h5b45459_0
         - certifi=2020.11.8=py37h03978a9_0
-        - cffi=1.14.3=py37hd6b71e5_1
+        - cffi=1.14.4=py37hd8e9650_1
         - cryptography=3.2.1=py37hd8e9650_0
-        - firefox=82.0=ha925a31_0
+        - firefox=83.0=h0e60522_0
         - geckodriver=0.28.0=h39d44d4_0
         - openssl=1.1.1h=he774522_0
         - pysocks=1.7.1=py37hf50a25e_2
-        - python=3.7.8=h60c2a47_1_cpython
+        - python=3.7.8=h7840368_3_cpython
         - selenium=3.141.0=py37h4ab8f01_1002
         - setuptools=49.6.0=py37hf50a25e_2
-        - sqlite=3.33.0=he774522_1
+        - sqlite=3.34.0=h8ffe710_0
         - vc=14.1=h869be7e_1
         - vs2015_runtime=14.16.27012=h30e32a0_2
         - win_inet_pton=1.1.0=py37hc8dfbb8_1

--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -37,12 +37,10 @@ env_specs:
       - win-64
     inherit_from:
       - ipyelk
+      - _utest
+      - _lint
     packages:
-      - black
-      - flake8
-      - isort <5
       - pip
-      - pyflakes
       - python >=3.7,<3.8.0a0
       - twine
       - wheel
@@ -65,6 +63,7 @@ env_specs:
       - python >=3.7
 
   atest:
+    description: acceptance test environment (kept separate because firefox)
     platforms:
       - linux-64
       - osx-64
@@ -80,3 +79,21 @@ env_specs:
       - robotframework-lint
       - robotframework-pabot
       - robotframework-seleniumlibrary
+
+  _lint:
+    description: linting/formatting environment. not actually created.
+    packages:
+      - black
+      - isort <5
+      - pyflakes
+      - flake8
+
+  _utest:
+    description: unit test environment. not actually created.
+    packages:
+      - ansi2html
+      - hypothesis-jsonschema
+      - pytest-asyncio
+      - pytest-cov
+      - pytest-html
+      - pytest-xdist

--- a/atest/Notebooks/Experiments.robot
+++ b/atest/Notebooks/Experiments.robot
@@ -20,8 +20,21 @@ ${SCREENS}        ${SCREENS ROOT}${/}notebook-experiments
     Linked Elk Output Counts Should Be    &{SIMPLE COUNTS}
 
 101_text_sizer
+    [Tags]    gh:48
     Example Should Restart-and-Run-All    ${TEXT SIZER}
     # not worth counting anything, doesn't put any elks on page
+    Click Element    xpath://button[contains(text(), 'Re-Calculate Size')]
+    ${sel} =    Set Variable    xpath://div[contains(@class, 'widget-label')][contains(text(), 'width:')]
+    Wait Until Page Contains Element    ${sel}
+    ${original} =    SeleniumLibrary.Get Element Attribute    ${sel}    textContent
+    Drag And Drop by Offset    css:.ui-slider-handle    100    0
+    Sleep    0.5s
+    ${size changed} =    SeleniumLibrary.Get Element Attribute    ${sel}    textContent
+    Select From List By Label    css:.widget-select select    monospace
+    Sleep    0.5s
+    ${font changed} =    SeleniumLibrary.Get Element Attribute    ${sel}    textContent
+    Should Not Be Equal as Strings    ${original}    ${size changed}
+    Should Not Be Equal as Strings    ${size changed}    ${font changed}
 
 102_layout_options
     [Tags]    data:simple.json

--- a/examples/101_text_sizer.ipynb
+++ b/examples/101_text_sizer.ipynb
@@ -80,9 +80,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "sizer.style"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "num = 10\n",
     "bulk_sizer = ipyelk.diagram.ElkTextSizer(\n",
-    "    max_size=num,\n",
+    "    max_size=num, style={\n",
+    "        \" .sprotty .elklabel.larger-font\": {\"font-size\": \"20px\"},\n",
+    "    }\n",
     ")"
    ]
   },
@@ -92,13 +103,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "async def send_bulk(num):\n",
+    "async def send_bulk_text(num):\n",
     "    texts = tuple(str(i) for i in range(num))\n",
     "    await bulk_sizer.measure(texts)\n",
     "    display(bulk_sizer.measure.cache_info())\n",
     "\n",
     "\n",
-    "asyncio.create_task(send_bulk(num))"
+    "asyncio.create_task(send_bulk_text(num))"
    ]
   },
   {
@@ -114,7 +125,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "bulk_sizer.raw_css"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "bulk_sizer.measure.cache_info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Size labels with css classes applied"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def label(i):\n",
+    "    return ipyelk.diagram.elk_model.ElkLabel(\n",
+    "        id=str(i), text=str(i), properties={\"cssClasses\": \"larger-font\"}\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "async def send_bulk_label(num):\n",
+    "    texts = tuple(label(i) for i in range(num))\n",
+    "    await bulk_sizer.measure(texts)\n",
+    "    display(bulk_sizer.measure.cache_info())\n",
+    "\n",
+    "\n",
+    "asyncio.create_task(send_bulk_label(num))"
    ]
   },
   {

--- a/examples/101_text_sizer.ipynb
+++ b/examples/101_text_sizer.ipynb
@@ -30,13 +30,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sizer = ipyelk.diagram.ElkTextSizer(\n",
-    "    custom_css=[],\n",
-    "    max_size=1,\n",
-    ")  # TODO implement custom css class injection so styles are correctly applied\n",
-    "button = ipywidgets.Button(description=\"Size\")\n",
-    "txt = ipywidgets.Text(description=\"Input Text\")\n",
-    "output = ipywidgets.Label(description=\"Text Size\")\n",
+    "sizer = ipyelk.diagram.ElkTextSizer(max_size=1)\n",
+    "button = ipywidgets.Button(description=\"Re-Calculate Size\")\n",
+    "txt = ipywidgets.Text(\"hello world\", description=\"Input Text\")\n",
+    "output = ipywidgets.Label()\n",
+    "font_size = ipywidgets.IntSlider(description=\"Font Size\", min=10, max=72)\n",
+    "font_family = ipywidgets.Select(\n",
+    "    description=\"Font Family\", options=[\"sans-serif\", \"monospace\"], rows=1\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def _on_resize_text(change):\n",
+    "    sizer.style = {\n",
+    "        \" text\": {\n",
+    "            \"font-size\": f\"{font_size.value}px !important\",\n",
+    "            \"font-family\": f\"{font_family.value} !important\",\n",
+    "        }\n",
+    "    }\n",
+    "    asyncio.create_task(call_measurement())\n",
+    "\n",
+    "\n",
+    "[it.observe(_on_resize_text, \"value\") for it in [font_size, font_family]]\n",
     "\n",
     "\n",
     "async def call_measurement(*args):\n",
@@ -46,7 +60,18 @@
     "\n",
     "txt.observe(lambda *args: asyncio.create_task(call_measurement()), \"value\")\n",
     "button.on_click(lambda *args: asyncio.create_task(call_measurement()))\n",
-    "ipywidgets.HBox([txt, button, output])"
+    "ipywidgets.VBox(\n",
+    "    [ipywidgets.HBox([txt, font_size, font_family]), ipywidgets.HBox([button, output])]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sizer.measure.cache_info()"
    ]
   },
   {

--- a/examples/101_text_sizer.ipynb
+++ b/examples/101_text_sizer.ipynb
@@ -91,9 +91,10 @@
    "source": [
     "num = 10\n",
     "bulk_sizer = ipyelk.diagram.ElkTextSizer(\n",
-    "    max_size=num, style={\n",
+    "    max_size=num,\n",
+    "    style={\n",
     "        \" .sprotty .elklabel.larger-font\": {\"font-size\": \"20px\"},\n",
-    "    }\n",
+    "    },\n",
     ")"
    ]
   },

--- a/examples/simple.json
+++ b/examples/simple.json
@@ -87,8 +87,5 @@
       }
     }
   ],
-  "id": "root",
-  "properties": {
-    "algorithm": "layered"
-  }
+  "id": "root"
 }

--- a/py_src/ipyelk/diagram/elk_model.py
+++ b/py_src/ipyelk/diagram/elk_model.py
@@ -12,6 +12,9 @@ from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, cast
 
 # Sentinel Value for tracking the root node in the Elk JSON
 ElkRoot = namedtuple("ElkRootNode", [])()
+# Sentinel Value for tracking hovered mark state
+ElkNullElement = namedtuple("ElkNullElement", [])()
+
 
 T = TypeVar("T")
 

--- a/py_src/ipyelk/diagram/elk_text_sizer.py
+++ b/py_src/ipyelk/diagram/elk_text_sizer.py
@@ -9,9 +9,9 @@ from typing import Dict, List, Union
 
 import traitlets as T
 from async_lru import alru_cache
-from ipywidgets import DOMWidget
 
 from .._version import EXTENSION_NAME, EXTENSION_SPEC_VERSION
+from ..styled_widget import StyledWidget
 from .elk_model import ElkLabel
 
 
@@ -43,7 +43,7 @@ class SizingRequest:
         return {"value": self.text.text, "cssClasses": css_classes, "id": self.id}
 
 
-class ElkTextSizer(DOMWidget):
+class ElkTextSizer(StyledWidget):
     """Jupyterlab widget for getting rendered text sizes from the DOM"""
 
     _model_name = T.Unicode("ELKTextSizerModel").tag(sync=True)
@@ -56,7 +56,6 @@ class ElkTextSizer(DOMWidget):
     _request_queue: asyncio.Queue = None
     _response_queue: asyncio.Queue = None
 
-    custom_css = T.List()
     timeout = T.Float(default_value=0.1, min=0)
     max_size = T.Int(default_value=100)
 
@@ -71,8 +70,9 @@ class ElkTextSizer(DOMWidget):
         asyncio.create_task(self._process_requests())
         asyncio.create_task(self._process_responses())
 
-    @T.observe("custom_css")
+    @T.observe("style")
     def _bust_futures_cache(self, change=None):
+        # TODO handle cache clearing
         pass
 
     def _handle_response(self, _, content, buffers):

--- a/py_src/ipyelk/diagram/elk_text_sizer.py
+++ b/py_src/ipyelk/diagram/elk_text_sizer.py
@@ -72,8 +72,7 @@ class ElkTextSizer(StyledWidget):
 
     @T.observe("style")
     def _bust_futures_cache(self, change=None):
-        # TODO handle cache clearing
-        pass
+        self.measure.cache_clear()
 
     def _handle_response(self, _, content, buffers):
         """Method to process messages back from the browser and resolve measurements"""

--- a/py_src/ipyelk/diagram/layout_options/__init__.py
+++ b/py_src/ipyelk/diagram/layout_options/__init__.py
@@ -5,6 +5,7 @@ https://www.eclipse.org/elk/reference/options.html
 # Distributed under the terms of the Modified BSD License.
 
 from .edge_options import (
+    Direction,
     EadesRepulsion,
     EdgeCenterLabelPlacementStrategy,
     EdgeEdgeLayerSpacing,
@@ -57,6 +58,7 @@ __all__ = [
     "CommentCommentSpacing",
     "CommentNodeSpacing",
     "ComponentsSpacing",
+    "Direction",
     "EadesRepulsion",
     "EdgeCenterLabelPlacementStrategy" "EdgeEdgeLayerSpacing",
     "EdgeCenterLabelPlacementStrategy",

--- a/py_src/ipyelk/diagram/layout_options/edge_options.py
+++ b/py_src/ipyelk/diagram/layout_options/edge_options.py
@@ -52,6 +52,14 @@ EDGE_ROUTING_OPTIONS = {
     "Splines": "SPLINES",
 }
 
+DIRECTION_OPTIONS = {
+    "Undefined": "UNDEFINED",
+    "Right": "RIGHT",
+    "Left": "LEFT",
+    "Down": "DOWN",
+    "Up": "UP",
+}
+
 
 class InlineEdgeLabels(LayoutOptionWidget):
     """If true, an edge label is placed directly on its edge. May only apply to
@@ -395,3 +403,23 @@ class MergeHierarchyCrossingEdges(LayoutOptionWidget):
     @T.observe("merge")
     def _update_value(self, change: T.Bunch = None):
         self.value = "true" if self.merge else "false"
+
+
+class Direction(LayoutOptionWidget):
+    """Overall direction of edges: horizontal (right / left) or vertical (down / up).
+
+    https://www.eclipse.org/elk/reference/options/org-eclipse-elk-direction.html
+    """
+    identifier = "org.eclipse.elk.direction"
+    metadata_provider = "core.options.CoreOptions"
+    applies_to = ["parents"]
+
+    value = T.Enum(
+        values=list(DIRECTION_OPTIONS.values()), default_value="UNDEFINED"
+    )
+
+    def _ui(self) -> List[W.Widget]:
+        dropdown = W.Dropdown(options=list(DIRECTION_OPTIONS.items()))
+        T.link((self, "value"), (dropdown, "value"))
+
+        return [dropdown]

--- a/py_src/ipyelk/nx/transformer.py
+++ b/py_src/ipyelk/nx/transformer.py
@@ -50,7 +50,7 @@ class XELK(ElkTransformer):
     css_classes = T.Dict()
 
     port_scale = T.Int(default_value=5)
-    label_key = T.Unicode(default_value="label")
+    label_key = T.Unicode(default_value="labels")
     port_key = T.Unicode(default_value="ports")
 
     text_sizer: ElkTextSizer = T.Instance(ElkTextSizer, kw={}, allow_none=True)
@@ -133,6 +133,7 @@ class XELK(ElkTransformer):
         :return: Root Elk node
         :rtype: ElkNode
         """
+        # TODO decide behavior for nodes that exist in the tree but not g
         g, tree = self.source
         self.clear_cached()
         ports: PortMap = self._ports
@@ -342,7 +343,7 @@ class XELK(ElkTransformer):
             properties = dict(cssClasses=" ".join(styles))
 
         labels = []
-        for i, label in enumerate(edge.data.get("labels", [])):
+        for i, label in enumerate(edge.data.get(self.label_key, [])):
             layout_options = self.get_layout(
                 edge.owner, ElkLabel
             )  # TODO add edgelabel type?

--- a/py_src/ipyelk/nx/transformer.py
+++ b/py_src/ipyelk/nx/transformer.py
@@ -659,7 +659,7 @@ class XELK(ElkTransformer):
         attr = self.HIDDEN_ATTR
         g, tree = self.source
         if node not in tree:
-            return None
+            return node
         if not is_hidden(tree, node, attr):
             return node
         predecesors = list(tree.predecessors(node))

--- a/py_src/ipyelk/nx/transformer.py
+++ b/py_src/ipyelk/nx/transformer.py
@@ -223,8 +223,11 @@ class XELK(ElkTransformer):
         return top  # returns top level node
 
     async def make_elknode(self, node) -> ElkNode:
-        layout = self.get_layout(node, ElkNode)
-
+        # merge layout options defined on the node data with default layout options
+        layout = merge(
+            self.get_node_data(node).get("layoutOptions", {}),
+            self.get_layout(node, ElkNode),
+        )
         labels = await self.make_labels(node)
 
         # update port map with declared ports in the networkx node data

--- a/py_src/ipyelk/styled_widget.py
+++ b/py_src/ipyelk/styled_widget.py
@@ -9,6 +9,7 @@ import traitlets as T
 class StyledWidget(W.Box):
     style = T.Dict(kw={})
     raw_css = T.Tuple().tag(sync=True)
+    namespaced_css = T.Unicode().tag(sync=True)
     _css_widget = T.Instance(W.HTML, kw={"layout": {"display": "None"}})
 
     def __init__(self, *args, **kwargs):
@@ -48,8 +49,9 @@ class StyledWidget(W.Box):
                     attributes.append(f"{key} {{{''.join(steps)}}}")
                 css_attributes = "\n".join(attributes)
             style.append(f"{selector}{{{css_attributes}}}")
+        self.namespaced_css = "".join(style)
         self.raw_css = raw_css
-        self._css_widget.value = f"<style>{''.join(style)}</style>"
+        self._css_widget.value = f"<style>{self.style}</style>"
 
     @property
     def _css_class(self) -> str:

--- a/py_src/ipyelk/tests/__init__.py
+++ b/py_src/ipyelk/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2020 Dane Freeman.
+# Distributed under the terms of the Modified BSD License.

--- a/py_src/ipyelk/tests/conftest.py
+++ b/py_src/ipyelk/tests/conftest.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2020 Dane Freeman.
+# Distributed under the terms of the Modified BSD License.

--- a/py_src/ipyelk/tests/test_meta.py
+++ b/py_src/ipyelk/tests/test_meta.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 Dane Freeman.
+# Distributed under the terms of the Modified BSD License.
+
+import ipyelk
+
+
+def test_meta():
+    assert hasattr(ipyelk, "__version__")

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -31,6 +31,9 @@ FORCE_SERIAL_ENV_PREP = bool(
 )
 # one of: None, wheel or sdist
 INSTALL_ARTIFACT = os.environ.get("INSTALL_ARTIFACT")
+UTEST_PROCESSES = os.environ.get(
+    "UTEST_PROCESSES", os.environ.get("ATEST_PROCESSES", "")
+)
 
 # find root
 SCRIPTS = Path(__file__).parent.resolve()
@@ -146,6 +149,12 @@ OK_NBLINT = {nb.name: BUILD / f"nblint.{nb.name}.ok" for nb in EXAMPLE_IPYNB}
 OK_PIP_INSTALL = BUILD / "pip_install.ok"
 OK_PRETTIER = BUILD / "prettier.ok"
 OK_INDEX = BUILD / "index.ox"
+
+HTMLCOV = BUILD / "htmlcov"
+HTMLCOV_INDEX = HTMLCOV / "index.html"
+PYTEST_COV_THRESHOLD = 17
+PYTEST_HTML = BUILD / "pytest.html"
+PYTEST_XUNIT = BUILD / "pytest.xunit.xml"
 
 # derived info
 PY_VERSION = re.findall(

--- a/scripts/reporter.py
+++ b/scripts/reporter.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2020 Dane Freeman.
+# Distributed under the terms of the Modified BSD License.
+#
+# from https://github.com/robots-from-jupyter/robotframework-jupyterlibrary
+#
+# Copyright (c) 2020 Robots from Jupyter
+# Distributed under the terms of the Modified BSD License.
+
+
+from datetime import datetime
+
+from doit.reporter import ConsoleReporter
+
+from . import project as P
+
+START = "::group::" if P.INSTALL_ARTIFACT else ""
+END = "\n::endgroup::" if P.INSTALL_ARTIFACT else ""
+
+TIMEFMT = "%H:%M:%S"
+SKIP = "        "
+
+
+class GithubActionsReporter(ConsoleReporter):
+    _gh_timings = {}
+
+    def execute_task(self, task):
+        start = datetime.now()
+        title = task.title()
+        self._gh_timings[title] = [start]
+        self.outstream.write(f"""{START}[{start.strftime(TIMEFMT)}] 🦌  {title}\n""")
+
+    def gh_outtro(self, task, emoji):
+        title = task.title()
+        start, end = self._gh_timings[title] = [
+            *self._gh_timings[title],
+            datetime.now(),
+        ]
+        delta = end - start
+        sec = str(delta.seconds).rjust(7)
+        self.outstream.write(f"{END}\n[{sec}s] {emoji} {task.title()} {emoji}\n")
+
+    def add_failure(self, task, exception):
+        super().add_failure(task, exception)
+        self.gh_outtro(task, "⭕")
+
+    def add_success(self, task):
+        super().add_success(task)
+        self.gh_outtro(task, "🏁 ")
+
+    def skip_uptodate(self, task):
+        self.outstream.write(f"{START}[{SKIP}] ⏩  {task.title()}{END}\n")
+
+    skip_ignore = skip_uptodate

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 Dane Freeman.
+# Distributed under the terms of the Modified BSD License.
+
+# from https://github.com/jupyrdf/ipyradiant/blob/master/_scripts/utils.py
+
+# Copyright (c) 2020 ipyradiant contributors.
+# Distributed under the terms of the Modified BSD License.
+import re
+
+RE_TIMESTAMP = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} -\d*"
+RE_PYTEST_TIMESTAMP = r"on \d{2}-[^\-]+-\d{4} at \d{2}:\d{2}:\d{2}"
+
+PATTERNS = [RE_TIMESTAMP, RE_PYTEST_TIMESTAMP]
+
+
+def strip_timestamps(*paths, slug="TIMESTAMP"):
+    """replace timestamps with a less churn-y value"""
+    for path in paths:
+        if not path.exists():
+            continue
+
+        text = original_text = path.read_text(encoding="utf-8")
+
+        for pattern in PATTERNS:
+            if not re.findall(pattern, text):
+                continue
+            text = re.sub(pattern, slug, text)
+
+        if text != original_text:
+            path.write_text(text)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,44 @@ install_requires =
 where =
     py_src
 
+[options.extras_require]
+lint =
+    black
+    isort <5
+    pyflakes
+    flake8
+utest =
+    ansi2html
+    hypothesis-jsonschema
+    pytest-asyncio
+    pytest-cov
+    pytest-html
+    pytest-xdist
+atest =
+    robotframework-seleniumlibrary
+    robotframework-pabot
+    robotframework-lint
+dev =
+    %(lint)s
+    %(utest)s
+    wheel
+    twine
+    doit
+
+[tool:pytest]
+junit_family = xunit2
+addopts =
+    -vv
+    --ff
+    --pyargs ipyelk
+    --cov ipyelk
+    --cov-report term-missing:skip-covered
+    --cov-report html:build/htmlcov
+    --no-cov-on-fail
+    --html build/pytest.html
+    --self-contained-html
+    --junitxml build/pytest.xunit.xml
+
 [flake8]
 exclude = .git,__pycache__,envs,.ipynb_checkpoints,.mypy_cache,.pytest-cache
 extend-ignore = E203,W503

--- a/src/elkschema.ts
+++ b/src/elkschema.ts
@@ -7,13 +7,22 @@
  */
 import * as ELK from 'elkjs';
 
+export interface ElkProperties {
+  cssClasses?: string;
+  LayoutOptions?: object;
+}
+
+export type AnyElkLabelWithProperties = ELK.ElkLabel & { properties?: ElkProperties };
+
 export interface LazyElkEdge extends ELK.ElkEdge {
   sources: string[];
   targets: string[];
+  labels?: AnyElkLabelWithProperties[];
 }
 
 export interface AnyElkPort extends ELK.ElkPort {
-  properties?: object;
+  properties?: ElkProperties;
+  labels?: AnyElkLabelWithProperties[];
 }
 
 export type AnyElkEdge =
@@ -22,13 +31,12 @@ export type AnyElkEdge =
   | ELK.ElkPrimitiveEdge
   | LazyElkEdge;
 
-export type AnyElkEdgeWithProperties = AnyElkEdge & { properties?: object };
-export type AnyElkLabelWithProperties = ELK.ElkLabel & { properties?: object };
+export type AnyElkEdgeWithProperties = AnyElkEdge & { properties?: ElkProperties };
 
 export interface AnyElkNode extends ELK.ElkNode {
   children?: AnyElkNode[];
   ports?: AnyElkPort[];
   edges?: AnyElkEdgeWithProperties[];
-  properties?: object;
+  properties?: ElkProperties;
   labels?: AnyElkLabelWithProperties[];
 }

--- a/src/elkschema.ts
+++ b/src/elkschema.ts
@@ -9,7 +9,6 @@ import * as ELK from 'elkjs';
 
 export interface ElkProperties {
   cssClasses?: string;
-  LayoutOptions?: object;
 }
 
 export type AnyElkLabelWithProperties = ELK.ElkLabel & { properties?: ElkProperties };

--- a/src/measure_text.ts
+++ b/src/measure_text.ts
@@ -41,7 +41,8 @@ export class ELKTextSizerModel extends DOMWidgetModel {
   make_container(): HTMLElement {
     let el: HTMLElement = document.body.appendChild(document.createElement('div'));
     el.classList.add('p-Widget', ELK_CSS.widget_class, ELK_CSS.sizer_class);
-    el.innerHTML = `<div class="sprotty"><svg class="sprotty-graph"><g></g></svg></div>`;
+    let raw_css: string = this.get('raw_css').join(''); //TODO should this `raw_css` string be escaped?
+    el.innerHTML = `<div class="sprotty"><style>${raw_css}</style><svg class="sprotty-graph"><g></g></svg></div>`;
     return el;
   }
 
@@ -91,7 +92,9 @@ export class ELKTextSizerModel extends DOMWidgetModel {
         event: 'measurement',
         measurements: this.read_sizes(content.texts, elements)
       };
-      // document.body.removeChild(el);
+      if (!ELK_DEBUG) {
+        document.body.removeChild(el);
+      }
       this.send(response, {}, []);
     });
   }

--- a/src/measure_text.ts
+++ b/src/measure_text.ts
@@ -6,15 +6,6 @@
 import { DOMWidgetModel, DOMWidgetView } from '@jupyter-widgets/base';
 import { NAME, VERSION, ELK_CSS, ELK_DEBUG } from '.';
 
-const TAG_REGEX = /[&<>'"]/g;
-const TAGS_TO_REPLACE = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '"&#039;'
-};
-
 export class ELKTextSizerModel extends DOMWidgetModel {
   static model_name = 'ELKTextSizerModel';
 
@@ -67,7 +58,7 @@ export class ELKTextSizerModel extends DOMWidgetModel {
     }
 
     label.classList.add(...classes);
-    label.textContent = escape(text.value);
+    label.textContent = text.value;
     ELK_DEBUG && console.warn('ELK Text Label', label);
     return label;
   }
@@ -100,7 +91,7 @@ export class ELKTextSizerModel extends DOMWidgetModel {
         event: 'measurement',
         measurements: this.read_sizes(content.texts, elements)
       };
-      document.body.removeChild(el);
+      // document.body.removeChild(el);
       this.send(response, {}, []);
     });
   }
@@ -157,17 +148,6 @@ export class ELKTextSizerView extends DOMWidgetView {
 
   model: ELKTextSizerModel;
   async render() {}
-}
-
-function escapeReplacer(tag: string): string {
-  return TAGS_TO_REPLACE[tag] || tag;
-}
-
-/**
- * Simple function to escape text for html before adding to dom
- */
-function escape(text: string) {
-  return text.replace(TAG_REGEX, escapeReplacer);
 }
 
 /**

--- a/src/measure_text.ts
+++ b/src/measure_text.ts
@@ -39,9 +39,17 @@ export class ELKTextSizerModel extends DOMWidgetModel {
   }
 
   make_container(): HTMLElement {
-    let el: HTMLElement = document.body.appendChild(document.createElement('div'));
-    el.classList.add('p-Widget', ELK_CSS.widget_class, ELK_CSS.sizer_class);
-    let raw_css: string = this.get('raw_css').join(''); //TODO should this `raw_css` string be escaped?
+    const el: HTMLElement = document.createElement('div');
+    const styledClass = this.get('_dom_classes').filter(
+      (dc: string) => dc.indexOf('styled-widget-') === 0
+    )[0];
+    el.classList.add(
+      'p-Widget',
+      ELK_CSS.widget_class,
+      ELK_CSS.sizer_class,
+      styledClass
+    );
+    const raw_css: string = this.get('namespaced_css'); //TODO should this `raw_css` string be escaped?
     el.innerHTML = `<div class="sprotty"><style>${raw_css}</style><svg class="sprotty-graph"><g></g></svg></div>`;
     return el;
   }
@@ -70,10 +78,10 @@ export class ELKTextSizerModel extends DOMWidgetModel {
    */
   measure(content: IELKTextSizeRequest) {
     ELK_DEBUG && console.warn('ELK Text Sizer Measure', content);
-    let el: HTMLElement = this.make_container();
-    let view: SVGElement = el.getElementsByTagName('g')[0];
+    const el: HTMLElement = this.make_container();
+    const view: SVGElement = el.getElementsByTagName('g')[0];
 
-    let new_g: SVGElement = createSVGElement('g');
+    const new_g: SVGElement = createSVGElement('g');
     content.texts.forEach(text => {
       new_g.appendChild(this.make_label(text));
     });
@@ -82,13 +90,15 @@ export class ELKTextSizerModel extends DOMWidgetModel {
     ELK_DEBUG && console.warn('ELK Text Sizer to add node', new_g);
     ELK_DEBUG && console.warn('ELK Text Sizer node', view);
 
+    document.body.prepend(el);
+
     let elements: SVGElement[] = Array.from(new_g.getElementsByTagName('text'));
 
-    el = document.body.appendChild(el);
     ELK_DEBUG && console.warn('Sized Text');
+
     // Callback to take measurements and remove element from DOM
     window.requestAnimationFrame(() => {
-      let response: IELKTextSizeResponse = {
+      const response: IELKTextSizeResponse = {
         event: 'measurement',
         measurements: this.read_sizes(content.texts, elements)
       };

--- a/style/index.css
+++ b/style/index.css
@@ -56,3 +56,9 @@
   box-shadow: inherit;
   color: var(--jp-warn-color0);
 }
+
+.jp-ElkSizer {
+  visibility: hidden;
+  z-index: -9999;
+  pointer-events: none;
+}


### PR DESCRIPTION
- [x] Fix label key
- [x] fix default visible node if it isn't in the `XELK` transformer tree
- [x] Fix label text sizing if the text includes quotes
- [x] Fix label sizer to respect custom css
- [x] Update Elk schema to allow for properties on edge labels and port labels
- [x] Add direction layout option widget
- [x] Merge `layoutOptions` defined in the node data with inherited options
- [x] adds `namespaced_css` to `StyleWidget`, used in TextSizer