### PR TITLE
Update some contributing docs, remove some warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## @jupyrdf/jupyter-elk 1.0.1
+
+- hides some browser console messages
+
+## ipyelk 1.0.1
+
+---
+
 ## @jupyrdf/jupyter-elk 1.0.0
 
 - updates for JupyterLab 3 ([#6][])

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,12 @@
 
 ## Install
 
-- Get [Miniforge](https://github.com/conda-forge/miniforge)
-- Get [anaconda-project](https://anaconda-project.readthedocs.io)
-- Get [doit](https://pydoit.org)
+- Get [Mambaforge](https://github.com/conda-forge/miniforge/releases/tag/4.9.2-5)
+- Get [anaconda-project](https://anaconda-project.readthedocs.io) and
+  [doit](https://pydoit.org)
 
 ```bash
-conda install anaconda-project=0.8.4 doit=0.32
-```
-
-To have an environment _similar_ to what's on CI:
-
-```bash
-CONDA_EXE=$(which mamba) CONDARC=.github/.condarc conda env update --file .github/environment.yml
+mamba install anaconda-project=0.8.4 doit=0.32
 ```
 
 ## Get Started
@@ -21,9 +15,22 @@ CONDA_EXE=$(which mamba) CONDARC=.github/.condarc conda env update --file .githu
 ```bash
 git clone https://github.com/jupyrdf/ipyelk
 cd ipyelk
-doit       # this is _basically_ what happens on binder
-doit lab   # start lab
+doit list --all # see what you can do
+doit            # this is _basically_ what happens on binder
+doit lab        # start lab
 ```
+
+## Branches
+
+Presently, on GitHub:
+
+- `master`: the `1.x` line, which distributes the lab extension inside the python
+  distribution for JupyterLab `>3`
+  - generates the `latest` tag on ReadTheDocs
+  - PRs welcome for new features or bugfixes here, backport fixes to `0.3.x`
+- `0.3.x`: the JupyterLab 1 (and, theoretically, 2) -compatible maintainence branch
+  - generates the `0.3.x` tag on ReadTheDocs
+  - PRs welcome for fixes here, forward-port to `master`
 
 ## Important Paths
 
@@ -112,6 +119,29 @@ Then run:
 
 ```bash
 ATEST_ARGS="--exclude NOTsome:tag" doit test:atest
+```
+
+## Building Documentation
+
+To build (and check the spelling and link health) of what _would_ go to
+`ipyelk.readthedocs.org`, we:
+
+- build with `sphinx` and `myst-nb`
+- check spelling with `hunspell`
+- check links with `pytest-check-links`
+
+```bash
+doit -n8 checkdocs
+```
+
+### Watch the Docs
+
+`sphinx-autobuild` will try to watch docs sources for changes, re-build, and serve a
+live-reloading website. A number of files (e.g. `_static`) won't often update correctly,
+but will usually work when restarted.
+
+```bash
+doit watch_docs
 ```
 
 ## Releasing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Presently, on GitHub:
   distribution for JupyterLab `>3`
   - generates the `latest` tag on ReadTheDocs
   - PRs welcome for new features or bugfixes here, backport fixes to `0.3.x`
-- `0.3.x`: the JupyterLab 1 (and, theoretically, 2) -compatible maintainence branch
+- `0.3.x`: the JupyterLab 1 (and, theoretically, 2) -compatible maintenance branch
   - generates the `0.3.x` tag on ReadTheDocs
   - PRs welcome for fixes here, forward-port to `master`
 

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -1,6 +1,7 @@
+2FA
 ci
 conda
-conda
+doit
 ipyelk
 js
 jupyrdf
@@ -8,9 +9,14 @@ jupyter
 Jupyter
 JupyterLab
 labextension
+maintainence
+Mambaforge
 networkx
 npm
+PRs
 pypi
 PyPI
+ReadTheDocs
 sprotty
+TypeScript
 WebWorker

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -9,7 +9,7 @@ jupyter
 Jupyter
 JupyterLab
 labextension
-maintainence
+maintenance
 Mambaforge
 networkx
 npm

--- a/dodo.py
+++ b/dodo.py
@@ -28,7 +28,6 @@ os.environ.update(
     PYTHONIOENCODING="utf-8",
     PIP_DISABLE_PIP_VERSION_CHECK="1",
     MAMBA_NO_BANNER="1",
-    CONDA_EXE="mamba",
 )
 
 DOIT_CONFIG = {

--- a/dodo.py
+++ b/dodo.py
@@ -17,7 +17,7 @@ from hashlib import sha256
 
 from doit import create_after
 from doit.action import CmdAction
-from doit.tools import PythonInteractiveAction, config_changed
+from doit.tools import LongRunning, PythonInteractiveAction, config_changed
 
 from scripts import project as P
 from scripts import reporter
@@ -27,6 +27,8 @@ os.environ.update(
     NODE_OPTS="--max-old-space-size=4096",
     PYTHONIOENCODING="utf-8",
     PIP_DISABLE_PIP_VERSION_CHECK="1",
+    MAMBA_NO_BANNER="1",
+    CONDA_EXE="mamba",
 )
 
 DOIT_CONFIG = {
@@ -585,6 +587,20 @@ def task_docs():
         file_dep=[P.DOCS_CONF, *P.ALL_PY_SRC, *P.ALL_MD],
         targets=[P.DOCS_BUILDINFO],
         actions=[[*P.APR_DOCS, "docs"]],
+    )
+
+
+def task_watch_docs():
+    """continuously rebuild the docs on change"""
+    yield dict(
+        uptodate=[lambda: False],
+        name="sphinx-autobuild",
+        file_dep=[P.DOCS_BUILDINFO, *P.ALL_MD],
+        actions=[
+            LongRunning(
+                [*P.APR_DOCS, "sphinx-autobuild", P.DOCS, P.DOCS_BUILD], shell=False
+            )
+        ],
     )
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyrdf/jupyter-elk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ElkJS widget for Jupyter",
   "keywords": [
     "jupyter",

--- a/postBuild
+++ b/postBuild
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """ a windows-friendly, binder-compatible script to get a development environment
 """
+# Copyright (c) 2021 Dane Freeman.
+# Distributed under the terms of the Modified BSD License.
 
 import shutil
 import subprocess

--- a/postBuild
+++ b/postBuild
@@ -3,15 +3,14 @@
 """
 
 import shutil
+import subprocess
 import sys
 from pathlib import Path
-from subprocess import check_call, check_output
 
 from jupyterlab_server.process import which
 
 NPM = which("npm") or which("npm.cmd") or which("npm.bat")
 JLPM = which("jlpm")
-
 
 HERE = Path.cwd()
 DIST = HERE / "dist"
@@ -20,11 +19,15 @@ DIST.exists() and shutil.rmtree(DIST)
 
 
 def _(*args, **kwargs):
+    _check = kwargs.pop("_check", True)
     if "cwd" in kwargs:
         kwargs["cwd"] = str(kwargs["cwd"])
     str_args = [str(a) for a in args]
     print(f"\n>>>\t{' '.join(str_args)}\n")
-    check_call(str_args, **kwargs)
+    if _check:
+        return subprocess.check_call(str_args, **kwargs)
+    else:
+        return subprocess.call(str_args, **kwargs)
 
 
 # preflight existing extensions
@@ -43,7 +46,8 @@ _(sys.executable, "-m", "pip", "install", "-e", ".", "--no-deps")
 _("jupyter", "labextension", "list")
 
 # disable bundled extensions
-_("jupyter", "labextension", "disable", "jupyter-offlinenotebook")
+_("jupyter", "labextension", "disable", "jupyter-offlinenotebook", _check=False)
+_("jupyter", "labextension", "uninstall", "jupyter-offlinenotebook", _check=False)
 
 # install our extension
 _("jupyter", "labextension", "develop", "--overwrite", ".")

--- a/postBuild
+++ b/postBuild
@@ -39,10 +39,14 @@ _(JLPM, "bootstrap")
 # install local python dev
 _(sys.executable, "-m", "pip", "install", "-e", ".", "--no-deps")
 
-_("jupyter", "labextension", "develop", "--overwrite", ".")
-
 # list the extensions
 _("jupyter", "labextension", "list")
+
+# disable bundled extensions
+_("jupyter", "labextension", "disable", "jupyter-offlinenotebook")
+
+# install our extension
+_("jupyter", "labextension", "develop", "--overwrite", ".")
 
 # list the extensions again
 _("jupyter", "labextension", "list")

--- a/py_src/ipyelk/_version.py
+++ b/py_src/ipyelk/_version.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Dane Freeman.
 # Distributed under the terms of the Modified BSD License.
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # The version of the attribute spec that this package
 # implements. This is the value used in
@@ -10,4 +10,4 @@ __version__ = "1.0.0"
 # Update this value when attributes are added/removed from
 # your models, or serialized format changes.
 EXTENSION_NAME = "@jupyrdf/jupyter-elk"
-EXTENSION_SPEC_VERSION = "1.0.0"
+EXTENSION_SPEC_VERSION = "1.0.1"

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -68,6 +68,7 @@ CHANGELOG = ROOT / "CHANGELOG.md"
 CONDARC = CI / ".condarc"
 README = ROOT / "README.md"
 DOCS = ROOT / "docs"
+POSTBUILD = ROOT / "postBuild"
 
 # tools
 PY = ["python"]
@@ -141,6 +142,7 @@ ALL_PY = [
     DOCS_CONF,
     DODO,
     SETUP_PY,
+    POSTBUILD,
 ]
 ALL_YML = [*ROOT.glob("*.yml"), *CI.rglob("*.yml")]
 ALL_JSON = [*ROOT.glob("*.json"), *EXAMPLE_JSON, PY_SCHEMA]

--- a/src/display_widget.ts
+++ b/src/display_widget.ts
@@ -73,7 +73,6 @@ export class ELKDiagramModel extends DOMWidgetModel {
 
   async value_changed() {
     let rootNode = this.get('value');
-    console.warn('layouting', rootNode);
     let layoutEngine: any = await this.layoutEngine(); // TODO need layoutEngine interface
     let result;
     if (layoutEngine) {

--- a/src/sprotty/diagram-server.ts
+++ b/src/sprotty/diagram-server.ts
@@ -25,7 +25,6 @@ export class JLModelSource extends LocalModelSource {
   async updateLayout(layout, defs, idPrefix: string) {
     this.elkToSprotty = new ElkGraphJsonToSprotty();
     let sGraph: SDefGraphSchema = this.elkToSprotty.transform(layout, defs, idPrefix);
-    console.warn('update layout');
     await this.updateModel(sGraph);
     // TODO this promise resolves before ModelViewer rendering is done. need to hook into postprocessing
   }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 export const NAME = '@jupyrdf/jupyter-elk';
-export const VERSION = '1.0.0';
+export const VERSION = '1.0.1';
 
 export const ELK_DEBUG = window.location.hash.indexOf('ELK_DEBUG') > -1;
 


### PR DESCRIPTION
- finishes up #70
- [x] squashes some `console.warn`
- [x] adds docs for docs and `watch_docs` task
- [x] bump to 1.0.1
- [x] get rid of `jupyterlab-offlinenotebook` in binder 
  - https://mybinder.org/v2/gh/nrbgt/ipyelk/post-100-docs-warnings?urlpath=lab
