### PR TITLE
Ensure lab is preflighted before running

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -549,7 +549,7 @@ def task_lab():
 
     return dict(
         uptodate=[lambda: False],
-        file_dep=[P.OK_PIP_INSTALL],
+        file_dep=[P.OK_PIP_INSTALL, P.OK_PREFLIGHT_LAB],
         actions=[PythonInteractiveAction(lab)],
     )
 


### PR DESCRIPTION
- fixes #79
- ensures the `preflight:lab` step runs before trying to start lab


## Test Procedure
- wait for CI
```bash
git clean -dxf
doit lab
```
- (should start lab)