### PR TITLE
fixing self edge bug

### DIFF
--- a/py_src/ipyelk/elements/layout_options/node_options.py
+++ b/py_src/ipyelk/elements/layout_options/node_options.py
@@ -412,10 +412,10 @@ class Padding(LayoutOptionWidget):
     metadata_provider = "core.options.CoreOptions"
     applies_to = ["parents", "nodes"]
 
-    top = T.Float(min_value=0, default_value=12)
-    bottom = T.Float(min_value=0, default_value=12)
-    left = T.Float(min_value=0, default_value=12)
-    right = T.Float(min_value=0, default_value=12)
+    top = T.Float(min=0, default_value=12)
+    bottom = T.Float(min=0, default_value=12)
+    left = T.Float(min=0, default_value=12)
+    right = T.Float(min=0, default_value=12)
 
     _traits = ["top", "bottom", "left", "right"]
 
@@ -486,7 +486,7 @@ class AspectRatio(LayoutOptionWidget):
     metadata_provider = "core.options.CoreOptions"
     applies_to = ["parents"]
 
-    ratio = T.Float(min_value=0, default_value=0.01)
+    ratio = T.Float(min=0, default_value=0.01)
 
     def _ui(self) -> List[W.Widget]:
         slider = W.FloatSlider(description="Aspect Ratio")

--- a/py_src/ipyelk/labextension/package.json
+++ b/py_src/ipyelk/labextension/package.json
@@ -80,7 +80,7 @@
       }
     },
     "_build": {
-      "load": "static/remoteEntry.d1981a39bba795871be2.js",
+      "load": "static/remoteEntry.383fba5f991ab3fd1489.js",
       "extension": "./extension",
       "style": "./style"
     }

--- a/py_src/ipyelk/loaders/nx/nxutils.py
+++ b/py_src/ipyelk/loaders/nx/nxutils.py
@@ -193,7 +193,15 @@ def lca(
     node1 = as_in_hierarchy(node1, hierarchy, el_map, nx_node_map)
     node2 = as_in_hierarchy(node2, hierarchy, el_map, nx_node_map)
 
-    ancestor = nx.lowest_common_ancestor(hierarchy, node1, node2)
+    if node1 is node2:
+        # self loops need to be owned by their parent
+        if not isinstance(node1, HierarchicalElement):
+            node = el_map[node1]
+        else:
+            node = node1
+        ancestor = node.get_parent()
+    else:
+        ancestor = nx.lowest_common_ancestor(hierarchy, node1, node2)
     if not isinstance(ancestor, HierarchicalElement):
         ancestor = el_map[ancestor]
     return ancestor

--- a/py_src/ipyelk/pipes/pipeline.py
+++ b/py_src/ipyelk/pipes/pipeline.py
@@ -88,7 +88,7 @@ class Pipeline(SyncedOutletPipe):
             prev = pipe.outlet
         self.outlet = prev
 
-        self.schedule_run()
+        # self.schedule_run()
 
     async def run(self):
         start = datetime.now()
@@ -99,22 +99,23 @@ class Pipeline(SyncedOutletPipe):
             # TODO use i and num_steps for reporting processing stage
             pipe_start_time = datetime.now()
             p_name = f"pipe {i}: {type(pipe)}"
-            if pipe.status.dirty():
-                self.status_update(PipeStatus.running(), pipe=pipe)
-                try:
+            try:
+                if pipe.status.dirty():
+                    self.status_update(PipeStatus.running(), pipe=pipe)
                     await pipe.run()
-                except Exception as err:
-                    self.log.exception(f"Error running {p_name}")
-                    self.status_update(
-                        PipeStatus.error(
-                            exception=err,
-                            start_time=pipe_start_time,
-                        ),
-                        pipe=pipe,
-                    )
-                    raise err
-            else:
-                pipe.outlet.value = pipe.inlet.value
+                else:
+                    pipe.outlet.value = pipe.inlet.value
+            except Exception as err:
+                self.log.exception(f"Error running {p_name}")
+                self.status_update(
+                    PipeStatus.error(
+                        exception=err,
+                        start_time=pipe_start_time,
+                    ),
+                    pipe=pipe,
+                )
+                raise err
+
             pipe.status_update(PipeStatus.finished(start_time=pipe_start_time))
         self.status_update(PipeStatus.finished(start_time=start))
 

--- a/py_src/ipyelk/tests/elements/test_edges.py
+++ b/py_src/ipyelk/tests/elements/test_edges.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2022 ipyelk contributors.
+# Distributed under the terms of the Modified BSD License.
+
+from ipyelk.elements import Edge, HierarchicalIndex, Label, Node, Port, Registry
+
+
+def test_self_edge_lca():
+    """The self edge from one port to another port should be owned by the root node."""
+    node = Node(labels=[Label(text="Node")])
+    port1 = Port(
+        labels=[Label(text="1")],
+        width=10,
+        height=10,
+    )
+
+    port2 = Port(
+        labels=[Label(text="2")],
+        width=10,
+        height=10,
+    )
+    node.add_port(port1)
+    node.add_port(port2)
+
+    node.add_edge(source=port1, target=port2)
+    root = Node(children=[node])
+
+    context = Registry()
+    with context:
+        index = HierarchicalIndex.from_els(root)
+        edge_report, id_report = index.get_reports()
+
+    assert len(edge_report.lca_mismatch) == 1
+    for edge, (current_owner, expected_owner) in edge_report.lca_mismatch.items():
+        assert isinstance(edge, Edge)
+        assert current_owner is node, "Root should be the new owner of the self edge"
+        assert expected_owner is root

--- a/py_src/ipyelk/tools/tool.py
+++ b/py_src/ipyelk/tools/tool.py
@@ -67,7 +67,7 @@ class Tool(W.Widget):
 
 class ToolButton(Tool):
     handler: Callable = T.Any(allow_none=True)
-    description: str = T.Unicode(default="")
+    description: str = T.Unicode(default_value="")
 
     @T.default("ui")
     def _default_ui(self):


### PR DESCRIPTION
Should address #101 but does require one change to the example. Self edges need to be owned by the node's parent. I added logic to move a self edge to it's parent, but in this case, the node needs to have a new `root` parent. Also added in some simple checks so if a root element has ports or labels it throws an error since those top level features are not rendered. 

```python
from ipyelk.elements import Edge, Label, Node, Port, HierarchicalIndex, Registry
from ipyelk import from_element

node = Node(labels=[Label(text="Node")])
port1 = Port(
    labels=[Label(text="1")],
    width=10,
    height=10,
)

port2 = Port(
    labels=[Label(text="2")],
    width=10,
    height=10,
)
node.add_port(port1)
node.add_port(port2)

node.add_edge(source=port1, target=port2)
root = Node(children=[node])
    
diagram = from_element(root)
diagram

```